### PR TITLE
Simplify target frameworks

### DIFF
--- a/GitReader.Core/GitReader.Core.csproj
+++ b/GitReader.Core/GitReader.Core.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net35;net40;net45;net461;net462;net48;net481;netstandard1.6;netstandard2.0;netstandard2.1;netcoreapp2.0;netcoreapp2.1;netcoreapp2.2;netcoreapp3.0;netcoreapp3.1;net5.0;net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>net35;net461;netstandard2.0;net5.0</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <IsPackable>true</IsPackable>
   </PropertyGroup>

--- a/GitReader/GitReader.csproj
+++ b/GitReader/GitReader.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net35;net40;net45;net461;net462;net48;net481;netstandard1.6;netstandard2.0;netstandard2.1;netcoreapp2.0;netcoreapp2.1;netcoreapp2.2;netcoreapp3.0;netcoreapp3.1;net5.0;net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>net35;net461;netstandard2.0;net5.0</TargetFrameworks>
     <IsPackable>true</IsPackable>
   </PropertyGroup>
 


### PR DESCRIPTION
Reduce drastically the number of target frameworks while keeping maximum compatibility.
Having so many target frameworks (18!) affects the developper experience:
- compilation is super slow for such a small library
- refactoring takes ages

It will also reduce the package size!

See https://github.com/kekyo/GitReader/pull/2#issuecomment-1550798435 for more details