### PR TITLE
Simple Benchmark

### DIFF
--- a/GitReader.Core/GitReader.Core.csproj
+++ b/GitReader.Core/GitReader.Core.csproj
@@ -7,7 +7,10 @@
   </PropertyGroup>
     
   <ItemGroup>
-    <PackageReference Include="Nullable" Version="1.3.1" PrivateAssets="All" />
+    <PackageReference Include="PolySharp" Version="1.13.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
   </ItemGroup>  
 
   <ItemGroup Condition="('$(TargetFramework)' == 'net45') OR ('$(TargetFramework)' == 'net461') OR ('$(TargetFramework)' == 'net462') OR ('$(TargetFramework)' == 'net48') OR ('$(TargetFramework)' == 'net481')">

--- a/GitReader.sln
+++ b/GitReader.sln
@@ -42,6 +42,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "gitexporttest", "tests\gite
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "gitexport", "samples\gitexport\gitexport.csproj", "{04192260-BFB9-490D-B835-E0E4311FEE93}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Benchmark", "samples\Benchmark\Benchmark.csproj", "{AAE6C35C-2281-4E7E-B720-E29DF4CC6CD4}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -84,6 +86,10 @@ Global
 		{04192260-BFB9-490D-B835-E0E4311FEE93}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{04192260-BFB9-490D-B835-E0E4311FEE93}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{04192260-BFB9-490D-B835-E0E4311FEE93}.Release|Any CPU.Build.0 = Release|Any CPU
+		{AAE6C35C-2281-4E7E-B720-E29DF4CC6CD4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{AAE6C35C-2281-4E7E-B720-E29DF4CC6CD4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{AAE6C35C-2281-4E7E-B720-E29DF4CC6CD4}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{AAE6C35C-2281-4E7E-B720-E29DF4CC6CD4}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -93,6 +99,7 @@ Global
 		{ED0ACA0C-1639-404B-825B-8FC79A384243} = {FA77DE1C-C141-4C03-AA63-DAFC2E624125}
 		{48C10B93-4D7A-4D44-974B-55677CB08B2D} = {FA77DE1C-C141-4C03-AA63-DAFC2E624125}
 		{04192260-BFB9-490D-B835-E0E4311FEE93} = {6C0A2BF1-2E5A-4040-9617-9438F1A8BBDD}
+		{AAE6C35C-2281-4E7E-B720-E29DF4CC6CD4} = {6C0A2BF1-2E5A-4040-9617-9438F1A8BBDD}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {AD39B2E0-9F24-4605-A51C-FF43CCA98564}

--- a/samples/Benchmark/Benchmark.csproj
+++ b/samples/Benchmark/Benchmark.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <OutputType>Exe</OutputType>
+        <TargetFrameworks>net48;net6.0;net7.0</TargetFrameworks>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+    </PropertyGroup>
+    
+    <ItemGroup>
+        <PackageReference Include="BenchmarkDotNet" Version="0.13.5" />
+        <PackageReference Include="LibGit2Sharp" Version="0.27.2" />
+        <PackageReference Include="PolySharp" Version="1.13.2">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+        </PackageReference>
+    </ItemGroup>
+    
+    <ItemGroup>
+      <ProjectReference Include="..\..\GitReader\GitReader.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/samples/Benchmark/Program.cs
+++ b/samples/Benchmark/Program.cs
@@ -1,0 +1,73 @@
+﻿// See https://aka.ms/new-console-template for more information
+
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Engines;
+using BenchmarkDotNet.Jobs;
+using BenchmarkDotNet.Running;
+using GitReader;
+using GitReader.Primitive;
+using GitReader.Structures;
+
+[SimpleJob(RunStrategy.Throughput, RuntimeMoniker.Net70)]
+[SimpleJob(RunStrategy.Throughput, RuntimeMoniker.Net60)]
+[SimpleJob(RunStrategy.Throughput, RuntimeMoniker.Net48)]
+public class GitRepo
+{
+    private string gitPath = string.Empty;
+     
+    [GlobalSetup]
+    public void GlobalSetup()
+    {
+        gitPath = Environment.GetEnvironmentVariable("GIT_PATH") ?? throw new InvalidOperationException("Please provide the path to a .git repository in command line");
+    }
+    
+    [Benchmark]
+    public async Task GitReader()
+    {
+        using var repository = await Repository.Factory.OpenPrimitiveAsync(gitPath);
+        var stashes = await repository.GetStashesAsync();
+        var branches = await repository.GetBranchHeadReferencesAsync();
+        var remoteBranches = await repository.GetRemoteBranchHeadReferencesAsync();
+        var tags = await repository.GetTagReferencesAsync();
+    }
+
+    [Benchmark]
+    public async Task GitReaderStructured()
+    {
+        using var repository = await Repository.Factory.OpenStructureAsync(gitPath);
+        var stashes = repository.Stashes.ToArray();
+        var branches = repository.Branches.Values.ToArray();
+        var remoteBranches = repository.RemoteBranches.Values.ToArray();
+        var tags = repository.Tags.Values.ToArray();
+        var currentBranch = repository.GetCurrentHead();
+    }
+
+    [Benchmark]
+    public void LibGit2sharp()
+    {
+        var repository = new LibGit2Sharp.Repository(gitPath);
+        var stashes = repository.Stashes.ToArray();
+        var branches = repository.Branches.Where(x => !x.IsRemote).ToArray();
+        var remoteBranches = repository.Branches.Where(x => x.IsRemote).ToArray();
+        var tags = repository.Tags.ToArray();
+        var currentBranch = repository.Head;
+        var currentTrackedBranch = repository.Head.TrackedBranch;
+        var currentTrackingDetails = repository.Head.TrackedBranch.TrackingDetails;
+    }
+}
+
+public class Program
+{
+    public static void Main(string[] args)
+    {
+        if (args is [ var repoPath])
+        {
+            args = new[] { "--filter", "*GitRepo*", "--envVars", $"GIT_PATH:{repoPath}" };
+            BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);
+        }
+        else
+        {
+            Console.WriteLine("Please provide the path to a .git repository in command line");
+        }
+    }
+}


### PR DESCRIPTION
- Simple benchmark that compares [GitReader](https://github.com/kekyo/GitReader) perf to [libGit2Sharp](https://github.com/libgit2/libgit2sharp/)
  - Repository is opened and we get all branches / stashes / tags
  - Tests are run for multiple frameworks
  - `GitReader` does not provide all info yet (for instance, it's missings tracked branches, tracking details etc...) 
- Use [PolySharp](https://www.nuget.org/packages/PolySharp) to allow using list patterns on older frameworks not only nullability

NB: I'm not too experienced with [Benchmark.Net](https://benchmarkdotnet.org) but there's probably room for improvements to make tests run faster without affecting the results

Here is an example of the output summary:

|              Method |            Runtime |       Mean |     Error |    StdDev |
|-------------------- |------------------- |-----------:|----------:|----------:|
|           GitReader |           .NET 6.0 |   4.865 ms | 0.0512 ms | 0.0454 ms |
| GitReaderStructured |           .NET 6.0 |  69.200 ms | 1.3674 ms | 1.4631 ms |
|        LibGit2sharp |           .NET 6.0 |  22.208 ms | 0.0958 ms | 0.0748 ms |
|           GitReader |           .NET 7.0 |   4.853 ms | 0.0210 ms | 0.0196 ms |
| GitReaderStructured |           .NET 7.0 |  68.018 ms | 0.8555 ms | 0.8002 ms |
|        LibGit2sharp |           .NET 7.0 |  22.183 ms | 0.1585 ms | 0.1405 ms |
|           GitReader | .NET Framework 4.8 |   8.096 ms | 0.0148 ms | 0.0138 ms |
| GitReaderStructured | .NET Framework 4.8 | 249.047 ms | 1.9543 ms | 1.8281 ms |
|        LibGit2sharp | .NET Framework 4.8 |  22.679 ms | 0.1812 ms | 0.1513 ms |
